### PR TITLE
Add MaxAttempts to Backoff

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+func TestMaxAttempts(t *testing.T) {
+
+	b := &Backoff{
+		Min:         100 * time.Millisecond,
+		Max:         10 * time.Second,
+		Factor:      2,
+		MaxAttempts: 2,
+	}
+
+	checkDuration(t, b, 100*time.Millisecond)
+	checkDuration(t, b, 200*time.Millisecond)
+	checkError(t, b, ErrMaxAttemptsExceeded)
+}
+
 func Test1(t *testing.T) {
 
 	b := &Backoff{
@@ -13,11 +27,11 @@ func Test1(t *testing.T) {
 		Factor: 2,
 	}
 
-	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Duration(), 200*time.Millisecond)
-	equals(t, b.Duration(), 400*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
+	checkDuration(t, b, 200*time.Millisecond)
+	checkDuration(t, b, 400*time.Millisecond)
 	b.Reset()
-	equals(t, b.Duration(), 100*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
 }
 
 func Test2(t *testing.T) {
@@ -28,11 +42,11 @@ func Test2(t *testing.T) {
 		Factor: 1.5,
 	}
 
-	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Duration(), 150*time.Millisecond)
-	equals(t, b.Duration(), 225*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
+	checkDuration(t, b, 150*time.Millisecond)
+	checkDuration(t, b, 225*time.Millisecond)
 	b.Reset()
-	equals(t, b.Duration(), 100*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
 }
 
 func Test3(t *testing.T) {
@@ -43,11 +57,11 @@ func Test3(t *testing.T) {
 		Factor: 1.75,
 	}
 
-	equals(t, b.Duration(), 100*time.Nanosecond)
-	equals(t, b.Duration(), 175*time.Nanosecond)
-	equals(t, b.Duration(), 306*time.Nanosecond)
+	checkDuration(t, b, 100*time.Nanosecond)
+	checkDuration(t, b, 175*time.Nanosecond)
+	checkDuration(t, b, 306*time.Nanosecond)
 	b.Reset()
-	equals(t, b.Duration(), 100*time.Nanosecond)
+	checkDuration(t, b, 100*time.Nanosecond)
 }
 
 func TestJitter(t *testing.T) {
@@ -58,11 +72,11 @@ func TestJitter(t *testing.T) {
 		Jitter: true,
 	}
 
-	equals(t, b.Duration(), 100*time.Millisecond)
-	between(t, b.Duration(), 100*time.Millisecond, 200*time.Millisecond)
-	between(t, b.Duration(), 100*time.Millisecond, 400*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
+	checkDurationJitter(t, b, 100*time.Millisecond, 200*time.Millisecond)
+	checkDurationJitter(t, b, 100*time.Millisecond, 400*time.Millisecond)
 	b.Reset()
-	equals(t, b.Duration(), 100*time.Millisecond)
+	checkDuration(t, b, 100*time.Millisecond)
 }
 
 func between(t *testing.T, actual, low, high time.Duration) {
@@ -77,5 +91,29 @@ func between(t *testing.T, actual, low, high time.Duration) {
 func equals(t *testing.T, d1, d2 time.Duration) {
 	if d1 != d2 {
 		t.Fatalf("Got %s, Expecting %s", d1, d2)
+	}
+}
+
+func checkDurationJitter(t *testing.T, b *Backoff, min, max time.Duration) {
+	d, err := b.Duration()
+	between(t, d, min, max)
+	if err != nil {
+		t.Fatal("Error returned")
+	}
+}
+
+func checkDuration(t *testing.T, b *Backoff, expected time.Duration) {
+	d, err := b.Duration()
+	equals(t, d, expected)
+	if err != nil {
+		t.Fatal("Error returned")
+	}
+}
+
+func checkError(t *testing.T, b *Backoff, expected error) {
+	d, err := b.Duration()
+	equals(t, d, 0)
+	if err != expected {
+		t.Fatalf("Got %s, Expecting %v", err, expected)
 	}
 }


### PR DESCRIPTION
The field MaxAttempts is added to the Backoff struct, this allows
the Duration method to fail with an error if a number of attempts
have been exceeded. The signature of Duration has been changed to
return a duration and an error.

Also this commit changes attempts from float64 to int and creates
a new test when exceeding the number of attempts.

Fixes: #2