### PR TITLE
Add threadsafety notes

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -10,6 +10,10 @@ import (
 //After every call to Duration() it is  multiplied by Factor.
 //It is capped at Max. It returns to Min on every call to Reset().
 //Used in conjunction with the time package.
+//
+// Backoff is not threadsafe, but the ForAttempt method can be
+// used concurrently if non-zero values for Factor, Max, and Min
+// are set on the Backoff shared among threads.
 type Backoff struct {
 	//Factor is the multiplying factor for each increment step
 	attempts, Factor float64
@@ -31,6 +35,9 @@ func (b *Backoff) Duration() time.Duration {
 // you have a large number of independent Backoffs, but don't want use
 // unnecessary memory storing the Backoff parameters per Backoff. The first
 // attempt should be 0.
+//
+// ForAttempt is threadsafe iff non-zero values for Factor, Max, and Min
+// are set before any calls to ForAttempt are made.
 func (b *Backoff) ForAttempt(attempt float64) time.Duration {
 	//Zero-values are nonsensical, so we use
 	//them to apply defaults


### PR DESCRIPTION
This is a comments-only change to note the threadsafety properties. It may be the case that ForAttempt is always threadsafe, but the Go race detector complains about the default setting on lines 44-52. And the workaround is quite easy.

Resolves #6 (in a way).