### PR TITLE
Add RetryOrCancel

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -77,6 +77,17 @@ func (b *Backoff) ForAttempt(attempt float64) time.Duration {
 	return dur
 }
 
+// RetryOrCancel returns true (after a pause) if Max is not exceeded and return false (immediately) otherwise
+// It's useful when you don't want to call time.Sleep in your code and want to stop your attempts after Max is exceeded
+func (b *Backoff) RetryOrCancel() bool {
+	dur := b.Duration()
+	if dur >= b.Max {
+		return false
+	}
+	time.Sleep(dur)
+	return true
+}
+
 // Reset restarts the current attempt counter at zero.
 func (b *Backoff) Reset() {
 	b.attempt = 0

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -110,6 +110,31 @@ func TestJitter(t *testing.T) {
 	equals(t, b.Duration(), 100*time.Millisecond)
 }
 
+func TestRetryOrCancel(t *testing.T) {
+	b := &Backoff{
+		Min:    1 * time.Millisecond,
+		Max:    4 * time.Millisecond,
+		Factor: 2,
+		Jitter: true,
+	}
+
+	if b.RetryOrCancel() != true {
+		t.Fatal("1st RetryOrCancel must return true")
+	}
+	if b.RetryOrCancel() != true {
+		t.Fatal("2nd RetryOrCancel must return true")
+	}
+	if b.RetryOrCancel() != true {
+		t.Fatal("4th RetryOrCancel must return true")
+	}
+	if b.RetryOrCancel() != false {
+		t.Fatal("5th RetryOrCancel must return false")
+	}
+	if b.RetryOrCancel() != false {
+		t.Fatal("6th RetryOrCancel must return false")
+	}
+}
+
 func between(t *testing.T, actual, low, high time.Duration) {
 	if actual < low {
 		t.Fatalf("Got %s, Expecting >= %s", actual, low)


### PR DESCRIPTION
Hi,

I need to cancel the attempts after maximum duration is reached, because after 10 minutes it's not important and I also want to stop bothering the broken service.
It also incapsulates the "waiting" logic and for me it makes my code cleaner.

Here is an example:

```golang
func CleanCacheWithRetry() {
	// Nothing new here
	b := &backoff.Backoff{
		Min:    1 * time.Second,
		Max:    10 * time.Minute,
		Factor: 2,
	}

	for {
		if err := cleanCache(); err != nil {
			if b.RetryOrCancel() { // This will call time.Sleep internally
				continue
			}
			// if we received false, then Max was exceeded.
			// Log the error.
		}
		return
	}
}
```

Open for your comments and ideas.