### PR TITLE
Make Duration safe for concurrent use

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -27,8 +27,7 @@ type Backoff struct {
 // Duration returns the duration for the current attempt before incrementing
 // the attempt counter. See ForAttempt.
 func (b *Backoff) Duration() time.Duration {
-	d := b.ForAttempt(float64(atomic.LoadUint64(&b.attempt)))
-	atomic.AddUint64(&b.attempt, 1)
+	d := b.ForAttempt(float64(atomic.AddUint64(&b.attempt, 1) - 1))
 	return d
 }
 

--- a/backoff.go
+++ b/backoff.go
@@ -27,7 +27,7 @@ type Backoff struct {
 // Duration returns the duration for the current attempt before incrementing
 // the attempt counter. See ForAttempt.
 func (b *Backoff) Duration() time.Duration {
-	d := b.ForAttempt(atomic.LoadUint64(&b.attempt))
+	d := b.ForAttempt(float64(atomic.LoadUint64(&b.attempt)))
 	atomic.AddUint64(&b.attempt, 1)
 	return d
 }
@@ -40,7 +40,7 @@ const maxInt64 = float64(math.MaxInt64 - 512)
 // attempt should be 0.
 //
 // ForAttempt is concurrent-safe.
-func (b *Backoff) ForAttempt(attempt uint64) time.Duration {
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
 	// Zero-values are nonsensical, so we use
 	// them to apply defaults
 	min := b.Min
@@ -61,7 +61,7 @@ func (b *Backoff) ForAttempt(attempt uint64) time.Duration {
 	}
 	//calculate this duration
 	minf := float64(min)
-	durf := minf * math.Pow(factor, float64(attempt))
+	durf := minf * math.Pow(factor, attempt)
 	if b.Jitter {
 		durf = rand.Float64()*(durf-minf) + minf
 	}
@@ -86,8 +86,8 @@ func (b *Backoff) Reset() {
 }
 
 // Attempt returns the current attempt counter value.
-func (b *Backoff) Attempt() uint64 {
-	return atomic.LoadUint64(&b.attempt)
+func (b *Backoff) Attempt() float64 {
+	return float64(atomic.LoadUint64(&b.attempt))
 }
 
 // Copy returns a backoff with equals constraints as the original

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -2,6 +2,7 @@ package backoff
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -118,6 +119,26 @@ func TestCopy(t *testing.T) {
 	}
 	b2 := b.Copy()
 	equals(t, b, b2)
+}
+
+func TestConcurrent(t *testing.T) {
+	b := &Backoff{
+		Min:    100 * time.Millisecond,
+		Max:    10 * time.Second,
+		Factor: 2,
+	}
+
+	wg := &sync.WaitGroup{}
+
+	test := func() {
+		time.Sleep(b.Duration())
+		wg.Done()
+	}
+
+	wg.Add(2)
+	go test()
+	go test()
+	wg.Wait()
 }
 
 func between(t *testing.T, actual, low, high time.Duration) {

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -83,17 +83,17 @@ func TestGetAttempt(t *testing.T) {
 		Max:    10 * time.Second,
 		Factor: 2,
 	}
-	equals(t, b.Attempt(), uint64(0))
+	equals(t, b.Attempt(), float64(0))
 	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Attempt(), uint64(1))
+	equals(t, b.Attempt(), float64(1))
 	equals(t, b.Duration(), 200*time.Millisecond)
-	equals(t, b.Attempt(), uint64(2))
+	equals(t, b.Attempt(), float64(2))
 	equals(t, b.Duration(), 400*time.Millisecond)
-	equals(t, b.Attempt(), uint64(3))
+	equals(t, b.Attempt(), float64(3))
 	b.Reset()
-	equals(t, b.Attempt(), uint64(0))
+	equals(t, b.Attempt(), float64(0))
 	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Attempt(), uint64(1))
+	equals(t, b.Attempt(), float64(1))
 }
 
 func TestJitter(t *testing.T) {

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -83,17 +83,17 @@ func TestGetAttempt(t *testing.T) {
 		Max:    10 * time.Second,
 		Factor: 2,
 	}
-	equals(t, b.Attempt(), float64(0))
+	equals(t, b.Attempt(), uint64(0))
 	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Attempt(), float64(1))
+	equals(t, b.Attempt(), uint64(1))
 	equals(t, b.Duration(), 200*time.Millisecond)
-	equals(t, b.Attempt(), float64(2))
+	equals(t, b.Attempt(), uint64(2))
 	equals(t, b.Duration(), 400*time.Millisecond)
-	equals(t, b.Attempt(), float64(3))
+	equals(t, b.Attempt(), uint64(3))
 	b.Reset()
-	equals(t, b.Attempt(), float64(0))
+	equals(t, b.Attempt(), uint64(0))
 	equals(t, b.Duration(), 100*time.Millisecond)
-	equals(t, b.Attempt(), float64(1))
+	equals(t, b.Attempt(), uint64(1))
 }
 
 func TestJitter(t *testing.T) {
@@ -142,6 +142,7 @@ func TestConcurrent(t *testing.T) {
 }
 
 func between(t *testing.T, actual, low, high time.Duration) {
+	t.Helper()
 	if actual < low {
 		t.Fatalf("Got %s, Expecting >= %s", actual, low)
 	}
@@ -151,6 +152,7 @@ func between(t *testing.T, actual, low, high time.Duration) {
 }
 
 func equals(t *testing.T, v1, v2 interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(v1, v2) {
 		t.Fatalf("Got %v, Expecting %v", v1, v2)
 	}


### PR DESCRIPTION
The comment in `ForAttempt` says that it's safe for concurrent use, which it is, but I believe it is misleading because `Duration` is not safe for concurrent use.

If you checkout f452bc9 and run the tests with race detection it confirms this:

```
#550 ❯❯❯ go test -v -race -covermode atomic ./...
=== RUN   Test1
--- PASS: Test1 (0.00s)
=== RUN   TestForAttempt
--- PASS: TestForAttempt (0.00s)
=== RUN   Test2
--- PASS: Test2 (0.00s)
=== RUN   Test3
--- PASS: Test3 (0.00s)
=== RUN   Test4
--- PASS: Test4 (0.00s)
=== RUN   TestGetAttempt
--- PASS: TestGetAttempt (0.00s)
=== RUN   TestJitter
--- PASS: TestJitter (0.00s)
=== RUN   TestCopy
--- PASS: TestCopy (0.00s)
=== RUN   TestConcurrent
==================
WARNING: DATA RACE
Read at 0x00c000100060 by goroutine 16:
  _/Users/eborgstrom/Projects/backoff.(*Backoff).Duration()
      /Users/eborgstrom/Projects/backoff/backoff.go:28 +0x56
  _/Users/eborgstrom/Projects/backoff.TestConcurrent.func1()
      /Users/eborgstrom/Projects/backoff/backoff_test.go:134 +0x4a

Previous write at 0x00c000100060 by goroutine 15:
  _/Users/eborgstrom/Projects/backoff.(*Backoff).Duration()
      /Users/eborgstrom/Projects/backoff/backoff.go:29 +0xa6
  _/Users/eborgstrom/Projects/backoff.TestConcurrent.func1()
      /Users/eborgstrom/Projects/backoff/backoff_test.go:134 +0x4a

Goroutine 16 (running) created at:
  _/Users/eborgstrom/Projects/backoff.TestConcurrent()
      /Users/eborgstrom/Projects/backoff/backoff_test.go:140 +0x1d0
  testing.tRunner()
      /usr/local/opt/go/libexec/src/testing/testing.go:865 +0x163

Goroutine 15 (running) created at:
  _/Users/eborgstrom/Projects/backoff.TestConcurrent()
      /Users/eborgstrom/Projects/backoff/backoff_test.go:139 +0x1ba
  testing.tRunner()
      /usr/local/opt/go/libexec/src/testing/testing.go:865 +0x163
==================
--- FAIL: TestConcurrent (0.20s)
    testing.go:809: race detected during execution of test
FAIL
coverage: 79.3% of statements
FAIL    _/Users/eborgstrom/Projects/backoff     0.256s
```

The changes in 3e39e52 switch this package to use the [atomic](https://golang.org/pkg/sync/atomic/) package for loading, incrementing, and resetting the `attempts` variable such that it is now safe to use `Duration` from multiple goroutines.