### PR TITLE
Explicitly document the default values

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -16,22 +16,22 @@ import (
 // be used concurrently.
 type Backoff struct {
 	attempt uint64
-	
+
 	// Factor is the multiplying factor for each increment step.
 	//
 	// Defaults to 2.
 	Factor float64
-	
+
 	// Jitter eases contention by randomizing backoff steps.
 	//
 	// Defaults to false.
 	Jitter bool
-	
+
 	// Minimum value of the counter.
 	//
 	// Defaults to 100 milliseconds.
-	Min 
-	
+	Min time.Duration
+
 	// Maximum value of the counter.
 	//
 	// Defaults to 10 seconds.

--- a/backoff.go
+++ b/backoff.go
@@ -16,12 +16,26 @@ import (
 // be used concurrently.
 type Backoff struct {
 	attempt uint64
-	// Factor is the multiplying factor for each increment step
+	
+	// Factor is the multiplying factor for each increment step.
+	//
+	// Defaults to 2.
 	Factor float64
-	// Jitter eases contention by randomizing backoff steps
+	
+	// Jitter eases contention by randomizing backoff steps.
+	//
+	// Defaults to false.
 	Jitter bool
-	// Min and Max are the minimum and maximum values of the counter
-	Min, Max time.Duration
+	
+	// Minimum value of the counter.
+	//
+	// Defaults to 100 milliseconds.
+	Min 
+	
+	// Maximum value of the counter.
+	//
+	// Defaults to 10 seconds.
+	Max time.Duration
 }
 
 // Duration returns the duration for the current attempt before incrementing


### PR DESCRIPTION
When going through the documentation in [go package documentation](https://pkg.go.dev/github.com/jpillora/backoff?utm_source=godoc) i was unable to find the sensible defaults used by the backoff. I had to read to code to understand the same. I felt this could be simplified.

The intent of this PR is to help improve the [go package documentation](https://pkg.go.dev/github.com/jpillora/backoff?utm_source=godoc) of the sensible defaults used by this package.

